### PR TITLE
Fix/repo

### DIFF
--- a/model/heya.go
+++ b/model/heya.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -14,5 +15,12 @@ type Heya struct {
 	LastEditorID uuid.UUID `gorm:"type:char(36);not null"`
 	CreatedAt    time.Time `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP"`
 	UpdatedAt    time.Time `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP"`
-	Deleted      bool      `gorm:"type:boolean;default:false;not null"`
+}
+
+type NullHeya struct {
+	ID           uuid.UUID
+	Title        sql.NullString
+	Description  sql.NullString
+	LastEditorID uuid.UUID
+	UpdatedAt    sql.NullTime
 }

--- a/model/heya.go
+++ b/model/heya.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -15,4 +16,15 @@ type Heya struct {
 	CreatedAt    time.Time `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP"`
 	UpdatedAt    time.Time `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP"`
 	Deleted      bool      `gorm:"type:boolean;default:false;not null"`
+}
+
+type NullHeya struct {
+	ID           uuid.UUID
+	Title        sql.NullString
+	Description  sql.NullString
+	CreatorID    uuid.UUID
+	LastEditorID uuid.UUID
+	CreatedAt    sql.NullTime
+	UpdatedAt    sql.NullTime
+	Deleted      sql.NullBool
 }

--- a/model/hiqidashi.go
+++ b/model/hiqidashi.go
@@ -31,5 +31,5 @@ type NullHiqidashi struct {
 	Description  sql.NullString
 	Drawing      sql.NullString
 	ColorID      sql.NullString
-	UpdatedAt    time.Time
+	UpdatedAt    sql.NullTime
 }

--- a/model/hiqidashi.go
+++ b/model/hiqidashi.go
@@ -16,9 +16,20 @@ type Hiqidashi struct {
 	Title        string         `gorm:"type:char(50);not null"`
 	Description  string         `gorm:"type:text;not null"`
 	Drawing      sql.NullString `gorm:"type:text"`
-	ColorID      int            `gorm:"type:TINYINT UNSIGNED;not null"`
+	ColorCode    string         `gorm:"type:char(7);default:#9E7A7A;not null"`
 	CreatedAt    time.Time      `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP;index:idx_hiqidashi_heya_id,priority:2,index:idx_hiqidashi_creator_id,priority:2"`
 	UpdatedAt    time.Time      `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP"`
 
 	ChildrenID []uuid.UUID `gorm:"-"`
+}
+
+type NullHiqidashi struct {
+	ID           uuid.UUID
+	LastEditorID uuid.UUID
+	ParentID     uuid.NullUUID
+	Title        sql.NullString
+	Description  sql.NullString
+	Drawing      sql.NullString
+	ColorID      sql.NullString
+	UpdatedAt    time.Time
 }

--- a/model/tsuna.go
+++ b/model/tsuna.go
@@ -8,3 +8,9 @@ type Tsuna struct {
 	HiqidashiOne uuid.UUID `gorm:"type:char(36);not null"`
 	HiqidashiTwo uuid.UUID `gorm:"type:char(36);not null"`
 }
+
+// NullTsuna Oneを変えずにtwoをUpdateする
+type NullTsuna struct {
+	ID           uuid.UUID
+	HiqidashiTwo uuid.UUID
+}

--- a/repository/errors.go
+++ b/repository/errors.go
@@ -7,4 +7,6 @@ var (
 	ErrNoRecordDeleted = errors.New("no record deleted")
 	// ErrNoRecordUpdated 更新するレコードがありませんでした
 	ErrNoRecordUpdated = errors.New("no record updated")
+	// ErrNillUUID UUIDがnullです
+	ErrNillUUID = errors.New("nil uuid")
 )

--- a/repository/heya.go
+++ b/repository/heya.go
@@ -10,6 +10,6 @@ type HeyaRepository interface {
 	GetHeyasID(ctx context.Context) ([]uuid.UUID, error)
 	GetHeyaByID(ctx context.Context, id uuid.UUID) (*model.Heya, error)
 	CreateHeya(ctx context.Context, heya *model.Heya) error
-	UpdateHeyaByID(ctx context.Context, heya *model.Heya) error
+	UpdateHeyaByID(ctx context.Context, heya *model.NullHeya) error
 	DeleteHeyaByID(ctx context.Context, id uuid.UUID) error
 }

--- a/repository/heya_impl.go
+++ b/repository/heya_impl.go
@@ -66,8 +66,8 @@ func (repo *GormRepository) CreateHeya(ctx context.Context, heya *model.Heya) er
 	return nil
 }
 
-func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.Heya) error {
-	if heya.ID == uuid.Nil {
+func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.NullHeya) error {
+	if heya.ID == uuid.Nil || heya.LastEditorID == uuid.Nil {
 		return ErrNillUUID
 	}
 
@@ -76,15 +76,18 @@ func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.Heya
 		return fmt.Errorf("failed to get db: %w", err)
 	}
 
-	heyaMap := map[string]interface{}{
-		"id":             heya.ID,
-		"title":          heya.Title,
-		"description":    heya.Description,
-		"creator_id":     heya.CreatorID,
-		"last_editor_id": heya.LastEditorID,
-		"created_at":     heya.CreatedAt,
-		"updated_at":     heya.UpdatedAt,
-		"deleted":        heya.Deleted,
+	heyaMap := map[string]interface{}{}
+
+	heyaMap["id"] = heya.ID
+	heyaMap["last_editor_id"] = heya.LastEditorID
+	if heya.Title.Valid {
+		heyaMap["title"] = heya.Title.String
+	}
+	if heya.Description.Valid {
+		heyaMap["description"] = heya.Description.String
+	}
+	if heya.UpdatedAt.Valid {
+		heyaMap["updated_at"] = heya.UpdatedAt
 	}
 
 	result := db.

--- a/repository/heya_impl.go
+++ b/repository/heya_impl.go
@@ -66,8 +66,8 @@ func (repo *GormRepository) CreateHeya(ctx context.Context, heya *model.Heya) er
 	return nil
 }
 
-func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.Heya) error {
-	if heya.ID == uuid.Nil {
+func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.NullHeya) error {
+	if heya.ID == uuid.Nil || heya.CreatorID == uuid.Nil || heya.LastEditorID == uuid.Nil {
 		return ErrNillUUID
 	}
 
@@ -76,15 +76,25 @@ func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.Heya
 		return fmt.Errorf("failed to get db: %w", err)
 	}
 
-	heyaMap := map[string]interface{}{
-		"id":             heya.ID,
-		"title":          heya.Title,
-		"description":    heya.Description,
-		"creator_id":     heya.CreatorID,
-		"last_editor_id": heya.LastEditorID,
-		"created_at":     heya.CreatedAt,
-		"updated_at":     heya.UpdatedAt,
-		"deleted":        heya.Deleted,
+	heyaMap := map[string]interface{}{}
+
+	heyaMap["id"] = heya.ID
+	heyaMap["creator_id"] = heya.CreatorID
+	heyaMap["last_editor_id"] = heya.LastEditorID
+	if heya.Title.Valid {
+		heyaMap["title"] = heya.Title.String
+	}
+	if heya.Description.Valid {
+		heyaMap["description"] = heya.Description.String
+	}
+	if heya.UpdatedAt.Valid {
+		heyaMap["created_at"] = heya.CreatedAt
+	}
+	if heya.CreatedAt.Valid {
+		heyaMap["updated_at"] = heya.UpdatedAt
+	}
+	if heya.Deleted.Valid {
+		heyaMap["deleted"] = heya.Deleted
 	}
 
 	result := db.

--- a/repository/heya_impl.go
+++ b/repository/heya_impl.go
@@ -95,7 +95,7 @@ func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.Null
 		Updates(&heyaMap)
 	err = result.Error
 	if err != nil {
-		return fmt.Errorf("failed to update heya :%w", err)
+		return fmt.Errorf("failed to update heya:%w", err)
 	}
 	if result.RowsAffected == 0 {
 		return ErrNoRecordUpdated

--- a/repository/heya_impl.go
+++ b/repository/heya_impl.go
@@ -27,6 +27,10 @@ func (repo *GormRepository) GetHeyasID(ctx context.Context) ([]uuid.UUID, error)
 }
 
 func (repo *GormRepository) GetHeyaByID(ctx context.Context, id uuid.UUID) (*model.Heya, error) {
+	if id == uuid.Nil {
+		return nil, ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get db: %w", err)
@@ -45,6 +49,10 @@ func (repo *GormRepository) GetHeyaByID(ctx context.Context, id uuid.UUID) (*mod
 }
 
 func (repo *GormRepository) CreateHeya(ctx context.Context, heya *model.Heya) error {
+	if heya.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -59,6 +67,10 @@ func (repo *GormRepository) CreateHeya(ctx context.Context, heya *model.Heya) er
 }
 
 func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.Heya) error {
+	if heya.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -90,6 +102,10 @@ func (repo *GormRepository) UpdateHeyaByID(ctx context.Context, heya *model.Heya
 }
 
 func (repo *GormRepository) DeleteHeyaByID(ctx context.Context, id uuid.UUID) error {
+	if id == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)

--- a/repository/hiqidashi.go
+++ b/repository/hiqidashi.go
@@ -9,8 +9,8 @@ import (
 type HiqidashiRepository interface {
 	GetHiqidashisByHeyaID(ctx context.Context, heyaID uuid.UUID) ([]*model.Hiqidashi, error)
 	GetHiqidashisByParentID(ctx context.Context, parentID uuid.UUID) ([]*model.Hiqidashi, error)
-	CreateHiqidashi(ctx context.Context, hiqidashi *model.Hiqidashi) error
+	CreateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error
 	DeleteHiqidashiByID(ctx context.Context, id uuid.UUID) error
-	UpdateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error
+	UpdateHiqidashiByID(ctx context.Context, hiqidashi *model.NullHiqidashi) error
 	DeleteHiqidashiDrawing(ctx context.Context, hiqidashi *model.Hiqidashi) error
 }

--- a/repository/hiqidashi.go
+++ b/repository/hiqidashi.go
@@ -9,8 +9,8 @@ import (
 type HiqidashiRepository interface {
 	GetHiqidashisByHeyaID(ctx context.Context, heyaID uuid.UUID) ([]*model.Hiqidashi, error)
 	GetHiqidashisByParentID(ctx context.Context, parentID uuid.UUID) ([]*model.Hiqidashi, error)
-	CreateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error
-	DeleteHiqidashi(ctx context.Context, id uuid.UUID) error
+	CreateHiqidashi(ctx context.Context, hiqidashi *model.Hiqidashi) error
+	DeleteHiqidashiByID(ctx context.Context, id uuid.UUID) error
 	UpdateHiqidashiByID(ctx context.Context, hiqidashi *model.NullHiqidashi) error
 	DeleteHiqidashiDrawing(ctx context.Context, hiqidashi *model.Hiqidashi) error
 }

--- a/repository/hiqidashi.go
+++ b/repository/hiqidashi.go
@@ -10,7 +10,7 @@ type HiqidashiRepository interface {
 	GetHiqidashisByHeyaID(ctx context.Context, heyaID uuid.UUID) ([]*model.Hiqidashi, error)
 	GetHiqidashisByParentID(ctx context.Context, parentID uuid.UUID) ([]*model.Hiqidashi, error)
 	CreateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error
-	DeleteHiqidashiByID(ctx context.Context, id uuid.UUID) error
+	DeleteHiqidashi(ctx context.Context, id uuid.UUID) error
 	UpdateHiqidashiByID(ctx context.Context, hiqidashi *model.NullHiqidashi) error
 	DeleteHiqidashiDrawing(ctx context.Context, hiqidashi *model.Hiqidashi) error
 }

--- a/repository/hiqidashi_impl.go
+++ b/repository/hiqidashi_impl.go
@@ -94,8 +94,8 @@ func (repo *GormRepository) DeleteHiqidashi(ctx context.Context, id uuid.UUID) e
 }
 
 // UpdateHiqidashiByID UpdateHiqidashi ヒキダシを更新
-func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error {
-	if hiqidashi.ID == uuid.Nil {
+func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *model.NullHiqidashi) error {
+	if hiqidashi.ID == uuid.Nil || hiqidashi.LastEditorID == uuid.Nil {
 		return ErrNillUUID
 	}
 
@@ -105,7 +105,8 @@ func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *
 	}
 
 	hiqidashiMap := map[string]interface{}{}
-
+	hiqidashiMap["id"] = hiqidashi.ID
+	hiqidashiMap["last_editor_id"] = hiqidashi.LastEditorID
 	if hiqidashi.ParentID.Valid {
 		hiqidashiMap["parent_id"] = hiqidashi.ParentID
 	} else {
@@ -116,17 +117,14 @@ func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *
 	} else {
 		hiqidashiMap["drawing"] = gorm.Expr("NULL")
 	}
-
-	hiqidashiMap = map[string]interface{}{
-		"id":             hiqidashi.ID,
-		"heya_id":        hiqidashi.HeyaID,
-		"creator_id":     hiqidashi.CreatorID,
-		"last_editor_id": hiqidashi.LastEditorID,
-		"title":          hiqidashi.Title,
-		"description":    hiqidashi.Description,
-		"colorID":        hiqidashi.ColorID,
-		"created_at":     hiqidashi.CreatedAt,
-		"updated_at":     hiqidashi.UpdatedAt,
+	if hiqidashi.Title.Valid {
+		hiqidashiMap["title"] = hiqidashi.Title
+	}
+	if hiqidashi.Description.Valid {
+		hiqidashiMap["description"] = hiqidashi.Description
+	}
+	if hiqidashi.UpdatedAt.Valid {
+		hiqidashiMap["updated_at"] = hiqidashi.UpdatedAt
 	}
 
 	result := db.
@@ -143,6 +141,6 @@ func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *
 	return nil
 }
 
-func (repo *GormRepository) DeleteHiqidashiDrawing(ctx context.Context, hiqidashi *model.Hiqidashi) error  {
+func (repo *GormRepository) DeleteHiqidashiDrawing(ctx context.Context, hiqidashi *model.Hiqidashi) error {
 
 }

--- a/repository/hiqidashi_impl.go
+++ b/repository/hiqidashi_impl.go
@@ -109,13 +109,9 @@ func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *
 	hiqidashiMap["last_editor_id"] = hiqidashi.LastEditorID
 	if hiqidashi.ParentID.Valid {
 		hiqidashiMap["parent_id"] = hiqidashi.ParentID
-	} else {
-		hiqidashiMap["parent_id"] = gorm.Expr("NULL")
 	}
 	if hiqidashi.Drawing.Valid {
 		hiqidashiMap["drawing"] = hiqidashi.Drawing
-	} else {
-		hiqidashiMap["drawing"] = gorm.Expr("NULL")
 	}
 	if hiqidashi.Title.Valid {
 		hiqidashiMap["title"] = hiqidashi.Title

--- a/repository/hiqidashi_impl.go
+++ b/repository/hiqidashi_impl.go
@@ -49,8 +49,8 @@ func (repo *GormRepository) GetHiqidashisByParentID(ctx context.Context, parentI
 	return hiqidashis, nil
 }
 
-// CreateHiqidashi  ヒキダシを作成
-func (repo *GormRepository) CreateHiqidashi(ctx context.Context, hiqidashi *model.Hiqidashi) error {
+// CreateHiqidashiByID CreateHiqidashi  ヒキダシを作成
+func (repo *GormRepository) CreateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error {
 	if hiqidashi.ID == uuid.Nil {
 		return ErrNillUUID
 	}
@@ -68,8 +68,8 @@ func (repo *GormRepository) CreateHiqidashi(ctx context.Context, hiqidashi *mode
 	return nil
 }
 
-// DeleteHiqidashi ヒキダシを削除
-func (repo *GormRepository) DeleteHiqidashi(ctx context.Context, id uuid.UUID) error {
+// DeleteHiqidashiByID DeleteHiqidashi ヒキダシを削除
+func (repo *GormRepository) DeleteHiqidashiByID(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return ErrNillUUID
 	}

--- a/repository/hiqidashi_impl.go
+++ b/repository/hiqidashi_impl.go
@@ -10,6 +10,9 @@ import (
 
 // GetHiqidashisByHeyaID ヘヤのすべてのヒキダシを取得
 func (repo *GormRepository) GetHiqidashisByHeyaID(ctx context.Context, heyaID uuid.UUID) ([]*model.Hiqidashi, error) {
+	if heyaID == uuid.Nil {
+		return nil, ErrNillUUID
+	}
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get db: %w", err)
@@ -48,6 +51,10 @@ func (repo *GormRepository) GetHiqidashisByParentID(ctx context.Context, parentI
 
 // CreateHiqidashi  ヒキダシを作成
 func (repo *GormRepository) CreateHiqidashi(ctx context.Context, hiqidashi *model.Hiqidashi) error {
+	if hiqidashi.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -63,6 +70,10 @@ func (repo *GormRepository) CreateHiqidashi(ctx context.Context, hiqidashi *mode
 
 // DeleteHiqidashi ヒキダシを削除
 func (repo *GormRepository) DeleteHiqidashi(ctx context.Context, id uuid.UUID) error {
+	if id == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -84,6 +95,10 @@ func (repo *GormRepository) DeleteHiqidashi(ctx context.Context, id uuid.UUID) e
 
 // UpdateHiqidashiByID UpdateHiqidashi ヒキダシを更新
 func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error {
+	if hiqidashi.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)

--- a/repository/hiqidashi_impl.go
+++ b/repository/hiqidashi_impl.go
@@ -68,8 +68,8 @@ func (repo *GormRepository) CreateHiqidashiByID(ctx context.Context, hiqidashi *
 	return nil
 }
 
-// DeleteHiqidashiByID DeleteHiqidashi ヒキダシを削除
-func (repo *GormRepository) DeleteHiqidashiByID(ctx context.Context, id uuid.UUID) error {
+// DeleteHiqidashi  ヒキダシを削除
+func (repo *GormRepository) DeleteHiqidashi(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return ErrNillUUID
 	}

--- a/repository/hiqidashi_impl.go
+++ b/repository/hiqidashi_impl.go
@@ -142,5 +142,25 @@ func (repo *GormRepository) UpdateHiqidashiByID(ctx context.Context, hiqidashi *
 }
 
 func (repo *GormRepository) DeleteHiqidashiDrawing(ctx context.Context, hiqidashi *model.Hiqidashi) error {
+	if hiqidashi.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+	if hiqidashi.Drawing.Valid {
+		return nil
+	}
 
+	db, err := repo.getDB(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get db: %w", err)
+	}
+
+	err = db.
+		Where("id = ?", hiqidashi.ID).
+		Update("drawing", gorm.Expr("NULL")).Error
+
+	if err != nil {
+		return fmt.Errorf("failed to drawing nil :%w", err)
+	}
+
+	return nil
 }

--- a/repository/hiqidashi_impl.go
+++ b/repository/hiqidashi_impl.go
@@ -49,8 +49,8 @@ func (repo *GormRepository) GetHiqidashisByParentID(ctx context.Context, parentI
 	return hiqidashis, nil
 }
 
-// CreateHiqidashiByID CreateHiqidashi  ヒキダシを作成
-func (repo *GormRepository) CreateHiqidashiByID(ctx context.Context, hiqidashi *model.Hiqidashi) error {
+// CreateHiqidashi  ヒキダシを作成
+func (repo *GormRepository) CreateHiqidashi(ctx context.Context, hiqidashi *model.Hiqidashi) error {
 	if hiqidashi.ID == uuid.Nil {
 		return ErrNillUUID
 	}
@@ -68,8 +68,8 @@ func (repo *GormRepository) CreateHiqidashiByID(ctx context.Context, hiqidashi *
 	return nil
 }
 
-// DeleteHiqidashi  ヒキダシを削除
-func (repo *GormRepository) DeleteHiqidashi(ctx context.Context, id uuid.UUID) error {
+// DeleteHiqidashiByID  ヒキダシを削除
+func (repo *GormRepository) DeleteHiqidashiByID(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return ErrNillUUID
 	}

--- a/repository/history_impl.go
+++ b/repository/history_impl.go
@@ -29,6 +29,10 @@ func (repo *GormRepository) GetHistoriesByUserID(ctx context.Context, userID uui
 
 // CreateHistory 履歴の作成
 func (repo *GormRepository) CreateHistory(ctx context.Context, history *model.History) error {
+	if history.UserID == uuid.Nil || history.HeyaID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -44,6 +48,10 @@ func (repo *GormRepository) CreateHistory(ctx context.Context, history *model.Hi
 
 // DeleteHistoryByHeyaID DeleteHistory ヘヤが削除されたときに削除する履歴
 func (repo *GormRepository) DeleteHistoryByHeyaID(ctx context.Context, heyaID uuid.UUID) error {
+	if heyaID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -3,4 +3,8 @@ package repository
 type Repository interface {
 	Transaction
 	UserRepository
+	HeyaRepository
+	HiqidashiRepository
+	HistoryRepository
+	TsunaRepository
 }

--- a/repository/tsuna.go
+++ b/repository/tsuna.go
@@ -10,5 +10,5 @@ type TsunaRepository interface {
 	GetTsunasByHeyaID(ctx context.Context, heyaID uuid.UUID) ([]*model.Tsuna, error)
 	CreateTsuna(ctx context.Context, tsuna *model.Tsuna) error
 	DeleteTsunaByID(ctx context.Context, id uuid.UUID) error
-	UpdateTsunaByID(ctx context.Context, tsuna *model.Tsuna) error
+	UpdateTsunaByID(ctx context.Context, tsuna *model.NullTsuna) error
 }

--- a/repository/tsuna_impl.go
+++ b/repository/tsuna_impl.go
@@ -68,9 +68,13 @@ func (repo *GormRepository) DeleteTsunaByID(ctx context.Context, id uuid.UUID) e
 }
 
 // UpdateTsunaByID UpdateTsuna ツナを更新する
-func (repo *GormRepository) UpdateTsunaByID(ctx context.Context, tsuna *model.Tsuna) error {
-	if tsuna.ID == uuid.Nil {
+func (repo *GormRepository) UpdateTsunaByID(ctx context.Context, tsuna *model.NullTsuna) error {
+	if tsuna.ID == uuid.Nil || tsuna.HiqidashiTwo == uuid.Nil {
 		return ErrNillUUID
+	}
+	tsunaMap := map[string]interface{}{
+		"id":            tsuna.ID,
+		"hiqidashi_two": tsuna.HiqidashiTwo,
 	}
 
 	db, err := repo.getDB(ctx)
@@ -78,8 +82,9 @@ func (repo *GormRepository) UpdateTsunaByID(ctx context.Context, tsuna *model.Ts
 		return fmt.Errorf("failed to get db: %w", err)
 	}
 
-	//ゼロ値であるフィールドがないので構造体のまま渡す
-	result := db.Updates(&tsuna)
+	result := db.
+		Model(model.Tsuna{}).
+		Updates(&tsunaMap)
 	err = result.Error
 	if err != nil {
 		return fmt.Errorf("failed to update tsuna :%w", err)

--- a/repository/tsuna_impl.go
+++ b/repository/tsuna_impl.go
@@ -29,6 +29,10 @@ func (repo *GormRepository) GetTsunasByHeyaID(ctx context.Context, heyaID uuid.U
 
 // CreateTsuna ツナを作成
 func (repo *GormRepository) CreateTsuna(ctx context.Context, tsuna *model.Tsuna) error {
+	if tsuna.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -65,6 +69,10 @@ func (repo *GormRepository) DeleteTsunaByID(ctx context.Context, id uuid.UUID) e
 
 // UpdateTsunaByID UpdateTsuna ツナを更新する
 func (repo *GormRepository) UpdateTsunaByID(ctx context.Context, tsuna *model.Tsuna) error {
+	if tsuna.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)

--- a/repository/user_impl.go
+++ b/repository/user_impl.go
@@ -46,6 +46,10 @@ func (repo *GormRepository) GetUserByID(ctx context.Context, id uuid.UUID) (*mod
 
 // CreateUser Userを作成
 func (repo *GormRepository) CreateUser(ctx context.Context, user *model.User) error {
+	if user.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -61,6 +65,10 @@ func (repo *GormRepository) CreateUser(ctx context.Context, user *model.User) er
 
 // DeleteUserByID Userを削除する
 func (repo *GormRepository) DeleteUserByID(ctx context.Context, id uuid.UUID) error {
+	if id == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)
@@ -82,6 +90,10 @@ func (repo *GormRepository) DeleteUserByID(ctx context.Context, id uuid.UUID) er
 
 // UpdateUserByID ユーザーの情報を更新
 func (repo *GormRepository) UpdateUserByID(ctx context.Context, user *model.User) error {
+	if user.ID == uuid.Nil {
+		return ErrNillUUID
+	}
+
 	db, err := repo.getDB(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get db: %w", err)

--- a/repository/user_impl.go
+++ b/repository/user_impl.go
@@ -90,7 +90,7 @@ func (repo *GormRepository) DeleteUserByID(ctx context.Context, id uuid.UUID) er
 
 // UpdateUserByID ユーザーの情報を更新
 func (repo *GormRepository) UpdateUserByID(ctx context.Context, user *model.User) error {
-	if user.ID == uuid.Nil {
+	if user.ID == uuid.Nil || user.IconFileID == uuid.Nil {
 		return ErrNillUUID
 	}
 


### PR DESCRIPTION
close: #64 
close: #68  

Update時のNull対応をしました


- Update、Delete、CreateでのIDがNULLの場合のエラーハンドリングを行いました
- Updateする際のNULLの対応を細かくしました
- DeleteHiqidashiDrawingメソッドを作成し、DrawingをNULLに設定しました